### PR TITLE
Fix remove delegator multi

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -174,9 +174,8 @@ type User @entity {
   # ===== Keep track of pending events ===== 
 
   "Reference to request to pending decrease stake"
-  pendingDecreaseStake: DecreaseStakeEvent  
-  "Reference to request to remove delegator"
-  pendingRemoveDelegator: RemoveDelegatorEvent
+  pendingDecreaseStake: DecreaseStakeEvent
+
   "Reference to request to update deployer cut"
   pendingUpdateDeployerCut: UpdateDeployerCutEvent
   "Reference to request to update undelegate stake"

--- a/schema.graphql
+++ b/schema.graphql
@@ -175,6 +175,8 @@ type User @entity {
 
   "Reference to request to pending decrease stake"
   pendingDecreaseStake: DecreaseStakeEvent
+  "DEPRECATED: Use event with service operator and delegator id"
+  pendingRemoveDelegator: RemoveDelegatorEvent
 
   "Reference to request to update deployer cut"
   pendingUpdateDeployerCut: UpdateDeployerCutEvent

--- a/src/mappings/delegateManager.ts
+++ b/src/mappings/delegateManager.ts
@@ -270,7 +270,7 @@ export function handleRemoveDelegatorRequested(event: RemoveDelegatorRequested):
   let serviceProvider = createOrLoadUser(event.params._serviceProvider, event.block.timestamp)
   let delegator = createOrLoadUser(event.params._delegator, event.block.timestamp)
 
-  let id = serviceProvider.id + delegator.id
+  let id = event.params._serviceProvider.toHexString() + event.params._delegator.toHexString()
   let removeDelegatorEvent = RemoveDelegatorEvent.load(id)
   if (removeDelegatorEvent == null) {
     removeDelegatorEvent = new RemoveDelegatorEvent(id)
@@ -285,12 +285,12 @@ export function handleRemoveDelegatorRequested(event: RemoveDelegatorRequested):
 
 export function handleRemoveDelegatorRequestCancelled(event: RemoveDelegatorRequestCancelled): void {
   let serviceProvider = createOrLoadUser(event.params._serviceProvider, event.block.timestamp)
-  let delegator = createOrLoadUser(event.params._delegator, event.block.timestamp)
 
-  let removeDelegatorEventId = serviceProvider.id + delegator.id
+  let removeDelegatorEventId = event.params._serviceProvider.toHexString() + event.params._delegator.toHexString()
   let removeDelegatorEvent = RemoveDelegatorEvent.load(removeDelegatorEventId)
-  if (removeDelegatorEvent === null || removeDelegatorEvent.status !== 'Requested') {
-    log.error('No associated remove delegator request to cancel: service provider:{}', [
+
+  if (removeDelegatorEvent === null) {
+    log.error('No remove delegator event for service provider :{}', [
       serviceProvider.id
     ])
     return
@@ -305,10 +305,10 @@ export function handleRemoveDelegatorRequestEvaluated(event: RemoveDelegatorRequ
   let serviceProvider = createOrLoadUser(event.params._serviceProvider, event.block.timestamp)
   let delegator = createOrLoadUser(event.params._delegator, event.block.timestamp)
 
-  let removeDelegatorEventId = serviceProvider.id + delegator.id
+  let removeDelegatorEventId = event.params._serviceProvider.toHexString() + event.params._delegator.toHexString()
   let removeDelegatorEvent = RemoveDelegatorEvent.load(removeDelegatorEventId)
-  if (removeDelegatorEvent === null || removeDelegatorEvent.status !== 'Requested') {
-    log.error('No associated remove delegator request to evaluate: service provider:{}', [
+  if (removeDelegatorEvent === null) {
+    log.error('No remove delegator event for service provider :{}', [
       serviceProvider.id
     ])
     return

--- a/src/mappings/delegateManager.ts
+++ b/src/mappings/delegateManager.ts
@@ -270,54 +270,55 @@ export function handleRemoveDelegatorRequested(event: RemoveDelegatorRequested):
   let serviceProvider = createOrLoadUser(event.params._serviceProvider, event.block.timestamp)
   let delegator = createOrLoadUser(event.params._delegator, event.block.timestamp)
 
-  let id = getRequestCountId()
-  let removeDelegatorEvent = new RemoveDelegatorEvent(id)
+  let id = serviceProvider.id + delegator.id
+  let removeDelegatorEvent = RemoveDelegatorEvent.load(id)
+  if (removeDelegatorEvent == null) {
+    removeDelegatorEvent = new RemoveDelegatorEvent(id)
+  }
   removeDelegatorEvent.status = 'Requested'
   removeDelegatorEvent.owner = serviceProvider.id
   removeDelegatorEvent.delegator = delegator.id
   removeDelegatorEvent.expiryBlock = event.params._lockupExpiryBlock
   removeDelegatorEvent.createdBlockNumber = event.block.number
   removeDelegatorEvent.save()
-
-  serviceProvider.pendingRemoveDelegator = removeDelegatorEvent.id
-  serviceProvider.save()
 }
 
 export function handleRemoveDelegatorRequestCancelled(event: RemoveDelegatorRequestCancelled): void {
   let serviceProvider = createOrLoadUser(event.params._serviceProvider, event.block.timestamp)
-  let removeDelegatorEventId = serviceProvider.pendingRemoveDelegator
-  if (removeDelegatorEventId === null) {
+  let delegator = createOrLoadUser(event.params._delegator, event.block.timestamp)
+
+  let removeDelegatorEventId = serviceProvider.id + delegator.id
+  let removeDelegatorEvent = RemoveDelegatorEvent.load(removeDelegatorEventId)
+  if (removeDelegatorEvent === null || removeDelegatorEvent.status !== 'Requested') {
     log.error('No associated remove delegator request to cancel: service provider:{}', [
       serviceProvider.id
     ])
+    return
   }
-  let removeDelegatorEvent = RemoveDelegatorEvent.load(removeDelegatorEventId)
+
   removeDelegatorEvent.status = 'Cancelled'
   removeDelegatorEvent.endedBlockNumber = event.block.number
   removeDelegatorEvent.save()
-
-  serviceProvider.pendingRemoveDelegator = null
-  serviceProvider.save()
 }
 
 export function handleRemoveDelegatorRequestEvaluated(event: RemoveDelegatorRequestEvaluated): void {
   let serviceProvider = createOrLoadUser(event.params._serviceProvider, event.block.timestamp)
   let delegator = createOrLoadUser(event.params._delegator, event.block.timestamp)
-  let removeDelegatorEventId = serviceProvider.pendingRemoveDelegator
-  if (removeDelegatorEventId === null) {
+
+  let removeDelegatorEventId = serviceProvider.id + delegator.id
+  let removeDelegatorEvent = RemoveDelegatorEvent.load(removeDelegatorEventId)
+  if (removeDelegatorEvent === null || removeDelegatorEvent.status !== 'Requested') {
     log.error('No associated remove delegator request to evaluate: service provider:{}', [
       serviceProvider.id
     ])
     return
   }
-  let removeDelegatorEvent = RemoveDelegatorEvent.load(removeDelegatorEventId)
   removeDelegatorEvent.status = 'Evaluated'
   removeDelegatorEvent.endedBlockNumber = event.block.number
   removeDelegatorEvent.save()
 
   serviceProvider.claimableDelegationReceivedAmount = serviceProvider.claimableDelegationReceivedAmount.minus(event.params._unstakedAmount)
   serviceProvider.delegationReceivedAmount = serviceProvider.delegationReceivedAmount.minus(event.params._unstakedAmount)
-  serviceProvider.pendingRemoveDelegator = null
   checkUserStakeDelegation(serviceProvider)
   serviceProvider.save()
 


### PR DESCRIPTION
There can be multiple requests to remove delegators from a service provider in flight.
1. RequestRemoveDelegator A
2. RequestRemoveDelegator B
3. CancelRequestRemoveDelegator A
4. CancelRequestRemoveDelegator B

The current graph indexer code is only set up to handle a single pending remove delegator. At step 4 above, an exception is thrown because the reference to the ID for the RequestRemoveDelegatorB is no longer stored.

This PR fixes that by creating an ID for RequestRemoveDelegator based on the ServiceProvider address + Delegator address